### PR TITLE
issue #2 problemCode Quickpick 기능을 추가했습니다.  

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -489,9 +489,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3131,9 +3131,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,8 @@ export function activate(context: ExtensionContext) {
     const userInfo = await getUserInfo();
     if (!userInfo) return;
     const { userID, currentSubmit } = userInfo;
-    const problemCode = await getProblemCode(currentSubmit);
+    // const problemCode = await getProblemCode(currentSubmit, submitHistory); // 추가) 제출코드 히스토리 전달
+    const problemCode = await getProblemCode(); // 전달 인자 필요 없음 (jota에서 문제리스트 가져오는 코드 추가 예정)
     if (!problemCode) return;
     const sourceCode = getTextFromEditor();
     if (!sourceCode) return;

--- a/src/userHandle.ts
+++ b/src/userHandle.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { window, workspace, Uri, WorkspaceFolder } from 'vscode';
+import { isDate } from 'util';
+import { window, workspace, Uri, WorkspaceFolder, commands } from 'vscode';
+import { getVSCodeDownloadUrl } from 'vscode-test/out/util';
 import { writeFile, readFile, windowPath } from './function';
 
 //열려있는 editor의 텍스트를 반환
@@ -19,8 +21,8 @@ export function getTextFromEditor(): String | undefined {
 export async function getUserInfo(): Promise<
   | {
     userID: string;
-    currentSubmit: string;
-    submitHistory: Array<string>,
+    currentSubmit: string; 
+    // submitHistory: Array<string>,
   }
   | undefined
 > {
@@ -41,13 +43,12 @@ export async function getUserInfo(): Promise<
     // {
     //   id: id,
     //   currentSubmit: submitProblemCode
-    //   submitHistory: problemCodeList
     // }
     // 로 이루어져있음
     const userInfo = {
       userID,
-      currentSubmit: '',
-      submitHistory: [],
+      currentSubmit: '', 
+      // submitHistory: [],
     };
 
     //유저의 정보를 기록
@@ -64,18 +65,35 @@ export async function getUserInfo(): Promise<
     window.showErrorMessage(`${fileUri.path} 형식 확인 필요.`);
   }
 }
-
+// 제출할 문제 코드 리턴
 export async function getProblemCode(
-  currentSubmit: string
+  // currentSubmit: string,
+  // submitHistory: string[]
 ): Promise<String | undefined> {
-  const problemCode = await window.showInputBox({
-    placeHolder: 'Write problem code',
-    value: currentSubmit,
-  });
+  //--- showInputBox는 엔터를 쳐야 다음 단계로 넘어가짐 -> 엔터를 쳐야 문제코드 히스토리가 보이는 문제..
+  // const problemCode = await window.showInputBox({
+  //   placeHolder: 'Write problem code',
+  //   value: currentSubmit,
+  // });
 
-  //제출 후 문제 번호 업데이트
+  let validProblemList = await getProblemListfromJOTA();
+
+  if(!validProblemList) return;
+  // showQuickPick : 전달해준 리스트에 있는 값만 problemCode로 리턴 가능 (새로운 값 입력 불가)
+  const problemCode = await window.showQuickPick(validProblemList, 
+  {
+      placeHolder: 'Write problem code',
+  });
   if (problemCode) updateUserCurrentSubmit(problemCode);
   return problemCode;
+}
+
+// jota에서 존재하는 문제 코드를 가져와서 리스트로 반환하는 함수
+// input: 없음, output: 존재하는 문제 코드 리스트 (string[])
+async function getProblemListfromJOTA():Promise<string[] | undefined> {
+  // TODO: jota에서 문제 코드 가져오기
+  let tempProblemList : string[] = ["aplusb","aminusb"]; // 임시 문제 코드 리스트
+  return tempProblemList;
 }
 
 //최근 제출 정보를 업데이트
@@ -83,7 +101,9 @@ async function updateUserCurrentSubmit(newSubmit: string) {
   const userInfo = await getUserInfo();
   if (!userInfo) return;
   userInfo.currentSubmit = newSubmit;
-  userInfo.submitHistory.push(newSubmit); //최근 제출 정보 히스토리에 추가
+  
+  //-- Inputfield로 입력받는 경우 제출한 적 있는 문제 코드 저장하기 위한 용도
+  // userInfo.submitHistory.push(newSubmit); //최근 제출 정보 히스토리에 추가
 
   const fileUri = getMetaFileUri();
   if (!fileUri) return;

--- a/src/userHandle.ts
+++ b/src/userHandle.ts
@@ -20,6 +20,7 @@ export async function getUserInfo(): Promise<
   | {
     userID: string;
     currentSubmit: string;
+    submitHistory: Array<string>,
   }
   | undefined
 > {
@@ -40,11 +41,13 @@ export async function getUserInfo(): Promise<
     // {
     //   id: id,
     //   currentSubmit: submitProblemCode
+    //   submitHistory: problemCodeList
     // }
     // 로 이루어져있음
     const userInfo = {
       userID,
       currentSubmit: '',
+      submitHistory: [],
     };
 
     //유저의 정보를 기록
@@ -80,6 +83,7 @@ async function updateUserCurrentSubmit(newSubmit: string) {
   const userInfo = await getUserInfo();
   if (!userInfo) return;
   userInfo.currentSubmit = newSubmit;
+  userInfo.submitHistory.push(newSubmit); //최근 제출 정보 히스토리에 추가
 
   const fileUri = getMetaFileUri();
   if (!fileUri) return;

--- a/src/userHandle.ts
+++ b/src/userHandle.ts
@@ -71,12 +71,12 @@ export async function getProblemCode(
   });
 
   //제출 후 문제 번호 업데이트
-  if (problemCode) updateUesrCurrentSubmit(problemCode);
+  if (problemCode) updateUserCurrentSubmit(problemCode);
   return problemCode;
 }
 
 //최근 제출 정보를 업데이트
-async function updateUesrCurrentSubmit(newSubmit: string) {
+async function updateUserCurrentSubmit(newSubmit: string) {
   const userInfo = await getUserInfo();
   if (!userInfo) return;
   userInfo.currentSubmit = newSubmit;


### PR DESCRIPTION
#2 에 해당하는 PR입니다.

### 기능 : 
제출 버튼을 누르면 임시로 저장해둔 문제 코드 리스트들이 inputbox 아래에 뜹니다. inputbox에 'ap'를 치면 'ap'로 시작하는 문제 코드 리스트만 뜹니다. 문제 코드를 모두 쓰고 엔터를 치거나, inputbox 아래에 떠있는 리스트 중 하나를 클릭하면 해당 문제로 제출이 됩니다. (리스트에 없는 문제 코드는 제출이 안됩니다.-> 잘못된 제출을 막을 수 있습니다.)
### 구현: 
문제코드의 리스트를 반환하는 함수를 만들었습니다. 현재는 임시로 저장해둔 문제 코드 리스트를 리턴하도록 함수가 구현되어있지만, JOTA에 존재하는 문제코드를 받아와서 jota 문제 코드를 리턴하는 내용으로 함수 내부를 변경할 예정입니다.

showQuickPick에 문제 코드 리스트를 전달하여 제출버튼을 누르면 해당 리스트가 뜨고, 선택을 하면 제출을 하도록 구현했습니다.
### 문제점:
기존 기능인 가장 최근 문제 코드가 자동완성 되는 기능은 showInputbox 함수로 구현했던 기능입니다. 문제 코드 리스트를 띄우려면 showQuickPick 함수를 사용해야 하는데 두 함수를 함께 사용할 방법을 찾지 못했습니다. 두 함수 모두 await로 입력을 대기하기 때문에 두 기능이 동시에 띄워지도록 할 수 없는 것으로 판단됩니다.
+++++++
#### <한 기능만 써야한다면 어떤 것이 더 좋을 지>
1. showInputbox를 사용한다면 : (기존 기능) 새로운 문제 코드 입력 가능, 최근 문제 코드 자동완성 기능 + 존재하지 않는 문제 코드에 접근 할 가능성(잘못된 제출이라는 메시지 뜸)
2. showQuickBox를 사용한다면 : (현재 PR 구현 내용) 존재하는 문제 코드 리스트를 받아와서 선택 항목을 인풋박스 밑에 띄워줌, 존재하지 않는 문제 코드로의 제출 막아줌 + 리스트에 없는 문제 코드로는 제출할 수 없음

&rarr; showQuickBox를 사용하는 방법이 더 안정적인 방법이라고 생각합니다. 실제 제출할 수 있는 문제 코드로만 제출이 가능하도록 되어있고, JOTA를 직접 들어가지 않아도 존재하는 문제 코드 리스트를 볼 수 있기 때문입니다. 그리고 인풋박스에 문제 코드의 일부만 적어도 해당 text로 시작하는 문제 코드 리스트만 간추려서 밑에 뜨기 때문에 사용하기 간편하다고 생각합니다.
+ 최근 제출한 문제 코드를 빠르게 제출하는 기능이 필요하다면, 리스트에서 가장 위에 최근 제출 코드가 뜨도록 하면 됩니다. 처음에는 리스트에서 가장 위에 있는 문제에 포커스가 맞춰져있기 때문에 엔터만 쳐도 가장 위에 있는 문제 코드로 선택이 됩니다.
(이에 대한 의견 부탁드립니다!)

### ***TODO: JOTA에서 현재 속해있는 contest에 있는 문제 코드들을 받아오는 방법 찾기 (getProblemListfromJOTA 함수 내부 변경)