### PR TITLE
issue #16 user가 속한 contest의 problem을 가져오는 이슈를 해결했습니다!

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ export function activate(context: ExtensionContext) {
     const userInfo = await getUserInfo();
     if (!userInfo) return;
     const { userID, currentSubmit } = userInfo;
-    const problemCode = await getProblemCode(currentSubmit);
+    const problemCode = await getProblemCode(userID, currentSubmit);
     if (!problemCode) return;
     const sourceCode = getTextFromEditor();
     if (!sourceCode) return;

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,4 +1,5 @@
 import { workspace, Uri, env } from 'vscode';
+import { JotaProblem } from './types';
 
 export function encodeUserId(id: string): string {
   const encode = (str: string): string => {
@@ -37,4 +38,24 @@ export async function writeFile(fileUri: Uri, text: string) {
 
 export async function showDetails(JotaURL: string) {
   env.openExternal(Uri.parse(JotaURL)); // 버튼 누르면 해당 URL로 이동
+}
+
+export function getProblemsListFromContest(
+  contestProblems: JotaProblem[],
+  problemInfoMap: Map<string, string>
+) {
+  // : Promise<string[] | undefined> {
+  //User에게 보여질 problem Name (problem Code)를 formatting 해주는 함수 선언
+  const formattingProblem = (problem: JotaProblem): string =>
+    `${problem.name} (${problem.code})`;
+  const problemNames = contestProblems.map((problem) =>
+    formattingProblem(problem)
+  );
+  // 문제 이름과 문제 코드로 이루어진 map 생성
+  // --- < key : 문제 이름, value: 문제 코드 > 인 map ---
+  contestProblems.forEach((problem) => {
+    // 문제를 하나씩 읽어옴 // 3문제면 3번 반복
+    problemInfoMap.set(formattingProblem(problem), problem.code); // (key, value)
+  });
+  return problemNames; // 문제 이름으로 반환
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -40,22 +40,25 @@ export async function showDetails(JotaURL: string) {
   env.openExternal(Uri.parse(JotaURL)); // 버튼 누르면 해당 URL로 이동
 }
 
-export function getProblemsListFromContest(
-  contestProblems: JotaProblem[],
-  problemInfoMap: Map<string, string>
-) {
-  // : Promise<string[] | undefined> {
+// input: user participate contest problems info
+// output: problems info Map
+export function getProblemsMapFromContest(contestProblems: JotaProblem[]) {
+  // ---problemsInfo---
+  // from JOTA (User가 속해있는 Contest에 존재하는 문제의 정보)
+  // <key:string, value:string>
+  // key: 'problemName(problemCode)' format, value: problemCode
+  const problemsInfoMap = new Map<string, string>();
+
   //User에게 보여질 problem Name (problem Code)를 formatting 해주는 함수 선언
   const formattingProblem = (problem: JotaProblem): string =>
     `${problem.name} (${problem.code})`;
-  const problemNames = contestProblems.map((problem) =>
-    formattingProblem(problem)
-  );
+
   // 문제 이름과 문제 코드로 이루어진 map 생성
   // --- < key : 문제 이름, value: 문제 코드 > 인 map ---
   contestProblems.forEach((problem) => {
     // 문제를 하나씩 읽어옴 // 3문제면 3번 반복
-    problemInfoMap.set(formattingProblem(problem), problem.code); // (key, value)
+    problemsInfoMap.set(formattingProblem(problem), problem.code); // (key, value)
   });
-  return problemNames; // 문제 이름으로 반환
+
+  return problemsInfoMap;
 }

--- a/src/jotaRest.ts
+++ b/src/jotaRest.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { window } from 'vscode';
+import { JotaProblem } from './types';
 
 // 모든 rest 요청을 하는 함수 이름은 반드시 REST_xxx
 
@@ -71,32 +72,14 @@ export async function REST_submit(
 }
 
 // Get problems in specific contest
-export async function REST_contestProblems(contests: string[]): Promise<
-  {
-    code: string; // problems code
-    is_pretesed: boolean;
-    label: string;
-    max_submissions: number;
-    name: string; // problems name
-    partial: boolean;
-    points: number;
-    contest: string;
-  }[]
-> {
+export async function REST_contestProblems(
+  contests: string[]
+): Promise<JotaProblem[]> {
   // input: contest id
   // output: List of problems at contest
   // TODO: type을 하나로 합칠 수 없을까?
 
-  const problems: {
-    code: string; // problems code
-    is_pretesed: boolean;
-    label: string;
-    max_submissions: number;
-    name: string; // problems name
-    partial: boolean;
-    points: number;
-    contest: string;
-  }[] = [];
+  const problems: JotaProblem[] = [];
 
   for (let i = 0; i < contests.length; i++) {
     const SUB_PATH: string = `/api/v2/contest/problem/${contests[i]}`; //contest problem 정보
@@ -105,21 +88,10 @@ export async function REST_contestProblems(contests: string[]): Promise<
     try {
       const response = await fetch(URL);
       const post = await response.json();
-      post.data.object.problems.forEach(
-        (problem: {
-          code: string; // problems code
-          is_pretesed: boolean;
-          label: string;
-          max_submissions: number;
-          name: string; // problems name
-          partial: boolean;
-          points: number;
-          contest: string;
-        }) => {
-          problem.contest = contests[i];
-          problems.push(problem);
-        }
-      );
+      post.data.object.problems.forEach((problem: JotaProblem) => {
+        problem.contest = contests[i];
+        problems.push(problem);
+      });
     } catch (error) {
       showErrorMsg();
     }
@@ -215,6 +187,7 @@ export async function REST_getProblemListFromJOTA(
       };
     } = await response.json();
     const JOTAproblemsInfo = post.data.objects; // JOTA에 존재하는 문제 정보(problemCode, problemName등) 가져옴
+    // console.log(typeof(JOTAproblemsInfo));
     const problemNames = JOTAproblemsInfo.map((problem) =>
       formattingProblem(problem.name, problem.code)
     ); // 문제 이름 저장, QuickPick 리스트가 배열을 받으므로 따로 이름 배열로 저장

--- a/src/jotaRest.ts
+++ b/src/jotaRest.ts
@@ -187,7 +187,6 @@ export async function REST_getProblemListFromJOTA(
       };
     } = await response.json();
     const JOTAproblemsInfo = post.data.objects; // JOTA에 존재하는 문제 정보(problemCode, problemName등) 가져옴
-    // console.log(typeof(JOTAproblemsInfo));
     const problemNames = JOTAproblemsInfo.map((problem) =>
       formattingProblem(problem.name, problem.code)
     ); // 문제 이름 저장, QuickPick 리스트가 배열을 받으므로 따로 이름 배열로 저장

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,10 @@
+export type JotaProblem = {
+  code: string; // problems code
+  is_pretesed: boolean;
+  label: string;
+  max_submissions: number;
+  name: string; // problems name
+  partial: boolean;
+  points: number;
+  contest: string;
+};

--- a/src/userHandle.ts
+++ b/src/userHandle.ts
@@ -139,7 +139,7 @@ export async function getProblemCode(
   if (!contestProblems) return;
   console.log(contestProblems);
   // let validProblemList = await REST_getProblemListFromJOTA(problemsInfoMap); // return all jota problem list
-  let validProblemList = await getProblemsListFromContest(
+  const validProblemList = await getProblemsListFromContest(
     contestProblems,
     problemsInfoMap
   );

--- a/src/userHandle.ts
+++ b/src/userHandle.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { window, workspace, Uri, WorkspaceFolder, commands } from 'vscode';
+import { getProblemsListFromContest } from './function';
 import {
   writeFile,
   readFile,
@@ -118,6 +119,7 @@ async function getUserContestProblems(encodedUserID: string): Promise<
 
 // Return source code that user want to submit
 export async function getProblemCode(
+  userID: string,
   currentSubmit: string
   // submitHistory: string[]
 ): Promise<string | undefined> {
@@ -132,8 +134,15 @@ export async function getProblemCode(
   // <key:string, value:string>
   // key: problemName, value: problemCode
   const problemsInfoMap = new Map<string, string>();
-
-  const validProblemList = await REST_getProblemListFromJOTA(problemsInfoMap);
+  // userID : encode state
+  const contestProblems = await getUserContestProblems(userID); // return "user participate contest" problem list
+  if (!contestProblems) return;
+  console.log(contestProblems);
+  // let validProblemList = await REST_getProblemListFromJOTA(problemsInfoMap); // return all jota problem list
+  let validProblemList = await getProblemsListFromContest(
+    contestProblems,
+    problemsInfoMap
+  );
   if (!validProblemList) return;
   const HighPriorityIdx = validProblemList.indexOf(currentSubmit); // 최근 제출 문제 인덱스 얻기
   if (HighPriorityIdx != -1) {


### PR DESCRIPTION
#16 과 관련된 PR입니다.

우선 jota의 problem을 가져오는 것의 목적은 사용자가 코드를 제출하기 위해 문제 이름을 입력할 때, 입력칸 밑에 Quickpick 리스트로 
jota에 있는 문제들을 띄워주기 위함입니다.

기존에는 jota에서 problem을 가져올 때, 다른 contest의 문제들까지 모두 가져오는 이슈가 있었습니다.
**해당 commit은 문제를 가져올 때 user가 속한 contest의 problem만을 가져와서 리스트로 띄우도록 했습니다.**

jota api를 이용해서 사용자가 속한 contest 정보를 받아오고 해당 contest의 문제들만을 가져오도록 했습니다.
가져온 문제의 정보는 문제 이름, 문제 코드를 이용해서 Map을 만들어 관리했습니다. 

감사합니다!